### PR TITLE
Add Craftium to third-party environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -35,6 +35,13 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)),
 
 Contextual extensions of popular reinforcement learning environments that enable training and test distributions for generalization, e.g. CartPole with variable pole lengths or Brax robots with different ground frictions.
 
+### [Craftium: an extensible framework for creating RL environments](https://github.com/mikelma/craftium)
+
+![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.29.1-blue)
+![GitHub stars](https://img.shields.io/github/stars/mikelma/craftium)
+
+Craftium wraps the [Minetest](https://www.minetest.net/) game engine into the Gymnasium API, providing a modern and easy-to-use platform for designing Minecraft-like RL environments. 
+
 ### [DACBench: a benchmark for Dynamic Algorithm Configuration](https://github.com/automl/DACBench)
 
 ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.26.3-blue)


### PR DESCRIPTION
# Description

Adds the [Craftium](https://github.com/mikelma/craftium/) project to the list of third-party environments.

## Type of change

- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes